### PR TITLE
Add README for SentryReceiver to documentation

### DIFF
--- a/docker-transfer/Dockerfile
+++ b/docker-transfer/Dockerfile
@@ -3,3 +3,4 @@ FROM scratch
 # Collect helm charts and documentation
 COPY charts/ /charts
 COPY docs/ /docs
+COPY receiver/sentryreceiver/README.md /docs/receivers/sentryreceiver.md


### PR DESCRIPTION
Include the README for SentryReceiver in the documentation directory to enhance clarity and usability.